### PR TITLE
Use package.json version as cli version

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -12,6 +12,7 @@ moment = require 'moment'
 redis = require 'redis'
 repl = require 'repl'
 stream = require 'stream'
+packageJson = require './package.json'
 
 config = require './config'
 
@@ -144,7 +145,7 @@ options =
     watchInterval: 200
 
 cli
-    .version '0.0.8'
+    .version packageJson.version
 
 cli
     .command 'stats'


### PR DESCRIPTION
Uses the package.json `version` field for the CLI version rather than writing this in code.

This means that there's only one place to change when the version is bumped.